### PR TITLE
Make compatible with 32-bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [0.2.0] - 2017-07-22
+
+### Added
+- This CHANGELOG file
+- A couple basic tests
+
+### Changed
+- `sysconf` function now returns c_long instead of i64. This potentially breaks backwards
+  compatability but is necessary to work with 32-bit OS's

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysconf"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Gary M. Josack <gary@byoteki.com>"]
 repository = "https://github.com/zerocostgoods/sysconf.rs"
 documentation = "https://docs.rs/sysconf"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-sysconf = "0.1.2"
+sysconf = "0.2.0"
 ```
 
 and this to your crate root:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate libc;
 
 use std::result;
-use self::libc::c_int;
+use self::libc::{c_int, c_long};
 
 pub type Result<T> = result::Result<T, SysconfError>;
 
@@ -70,9 +70,21 @@ pub enum SysconfVariable {
     ScXbs5LpbigOffbig = 128,
 }
 
-pub fn sysconf(name: SysconfVariable) -> Result<i64> {
+pub fn sysconf(name: SysconfVariable) -> Result<c_long> {
     match unsafe { libc::sysconf(name as c_int) } {
         -1  => Err(SysconfError::Invalid),
         ret => Ok(ret),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_valid_sysconf() {
+        let result = sysconf(SysconfVariable::ScPagesize);
+        assert!(result.is_ok())
     }
 }


### PR DESCRIPTION
- Updated sysconf function to return c_long for 32-bit compat
  - Fixes #4
- Added very basic test
- Added a changelog
- Bumped version for new release