### PR TITLE
Add high-level wrappers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
   - beta
   - stable
   # Minimum usable version of rust required.
-  - 1.0.0
+  - 1.8.0
 
 # Load travis-cargo
 before_script:
@@ -22,6 +22,7 @@ script:
   - |
       travis-cargo build &&
       travis-cargo test &&
+      travis-cargo --only nightly test -- --features nightly &&
       travis-cargo bench &&
       travis-cargo --only stable doc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2017-08-29
+
+### Added
+- A `page` module for querying information related to memory pages.
+
+### Changed
+- Moved the `sysconf` function and related types to their own `raw` module.
+- The `sysconf` function now returns `isize` instead of `c_long`. `c_long`
+  (which is what `libc`'s `sysconf` returns) is always 64 bits on 64-bit
+  platforms, so this is safe - we will never cast the return value of `sysconf`
+  to a smaller type, losing precision.
+- Renamed `SysconfError::Invalid` to `SysconfError::Unsupported` to reflect the
+  fact that the error doesn't indicate that the requested variable can never be
+  valid, but only that it is not supported on the current platform.
+
 ## [0.2.0] - 2017-07-22
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,19 @@
 [package]
 name = "sysconf"
-version = "0.2.0"
-authors = ["Gary M. Josack <gary@byoteki.com>"]
+version = "0.3.0"
+authors = ["Gary M. Josack <gary@byoteki.com>, Joshua Liebow-Feeser <hello@joshlf.com>"]
 repository = "https://github.com/zerocostgoods/sysconf.rs"
 documentation = "https://docs.rs/sysconf"
 license = "MIT OR Apache-2.0"
 description = "Small safe wrapper around sysconf"
 
-[dependencies]
-libc = "0.2.4"
+[features]
+nightly = ["lazy_static"]
 
+[dependencies]
+errno = "0.2"
+# lazy_static only supports no-std on nightly, so it's optional and enabled
+# by the 'nightly' feature
+lazy_static = { version = "0.2", features = ["spin_no_std"], optional = true }
+# use no_std libc
+libc = { version = "0.2", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,90 +1,30 @@
-extern crate libc;
+//! Query runtime configuration information.
+//!
+//! This crate provides the ability to query for various configuration information about the
+//! runtime platform such as memory page size. On POSIX systems, it makes heavy use of the
+//! [sysconf] API.
+//!
+//! [sysconf]: http://man7.org/linux/man-pages/man3/sysconf.3.html
 
-use std::result;
-use self::libc::{c_int, c_long};
+// NOTE: According to Wikipedia, "Originally, the name "POSIX" referred to IEEE Std 1003.1-1988,
+// released in 1988." This crate assumes that any behavior required by POSIX 1003.1 will be
+// properly implemented on any POSIX system. Running on a POSIX system which does not adhere to
+// these requirements will cause either an assertion failure/panic or undefined behavior.
 
-pub type Result<T> = result::Result<T, SysconfError>;
+#![cfg_attr(not(test), no_std)]
 
-#[derive(Debug)]
-pub enum SysconfError {
-    Invalid
-}
+#[cfg(test)] // In tests, we disable no_std, so core isn't automatically included
+extern crate core;
+// no-std lazy_static requires nightly
+// TODO: Use lazy_static unconditionally once it works on stable
+#[cfg(feature = "nightly")]
+#[macro_use]
+extern crate lazy_static;
 
-pub enum SysconfVariable {
-    ScArgMax = 0,
-    ScChildMax = 1,
-    ScClkTck = 2,
-    ScNgroupsMax = 3,
-    ScOpenMax = 4,
-    ScStreamMax = 5,
-    ScTznameMax = 6,
-    ScJobControl = 7,
-    ScSavedIds = 8,
-    ScRealtimeSignals = 9,
-    ScPriorityScheduling = 10,
-    ScTimers = 11,
-    ScAsynchronousIo = 12,
-    ScPrioritizedIo = 13,
-    ScSynchronizedIo = 14,
-    ScFsync = 15,
-    ScMappedFiles = 16,
-    ScMemlock = 17,
-    ScMemlockRange = 18,
-    ScMemoryProtection = 19,
-    ScMessagePassing = 20,
-    ScSemaphores = 21,
-    ScSharedMemoryObjects = 22,
-    ScAioListioMax = 23,
-    ScAioMax = 24,
-    ScAioPrioDeltaMax = 25,
-    ScDelaytimerMax = 26,
-    ScMqOpenMax = 27,
-    ScVersion = 29,
-    ScPagesize = 30,
-    ScRtsigMax = 31,
-    ScSemNsemsMax = 32,
-    ScSemValueMax = 33,
-    ScSigqueueMax = 34,
-    ScTimerMax = 35,
-    ScBcBaseMax = 36,
-    ScBcDimMax = 37,
-    ScBcScaleMax = 38,
-    ScBcStringMax = 39,
-    ScCollWeightsMax = 40,
-    ScExprNestMax = 42,
-    ScLineMax = 43,
-    ScReDupMax = 44,
-    Sc2Version = 46,
-    Sc2CBind = 47,
-    Sc2CDev = 48,
-    Sc2FortDev = 49,
-    Sc2FortRun = 50,
-    Sc2SwDev = 51,
-    Sc2Localedef = 52,
-    ScNprocessorsOnln = 84,
-    Sc2CharTerm = 95,
-    Sc2CVersion = 96,
-    Sc2Upe = 97,
-    ScXbs5Ilp32Off32 = 125,
-    ScXbs5Ilp32Offbig = 126,
-    ScXbs5LpbigOffbig = 128,
-}
+pub mod page;
+#[cfg(unix)]
+pub mod raw;
 
-pub fn sysconf(name: SysconfVariable) -> Result<c_long> {
-    match unsafe { libc::sysconf(name as c_int) } {
-        -1  => Err(SysconfError::Invalid),
-        ret => Ok(ret),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-
-    use super::*;
-
-    #[test]
-    fn test_valid_sysconf() {
-        let result = sysconf(SysconfVariable::ScPagesize);
-        assert!(result.is_ok())
-    }
-}
+pub use page::*;
+#[cfg(unix)]
+pub use raw::*;

--- a/src/page/hugepage.rs
+++ b/src/page/hugepage.rs
@@ -1,0 +1,431 @@
+#[cfg(target_os = "linux")]
+extern crate libc;
+#[cfg(target_os = "linux")]
+extern crate errno;
+
+/// Determine whether huge pages of a particular size are supported.
+#[cfg(target_os = "linux")]
+#[cfg_attr(feature = "cargo-clippy", allow(inline_always))]
+#[inline(always)]
+#[cfg(all(feature = "nightly", target_pointer_width = "32"))]
+pub fn hugepage_supported(size: usize) -> bool {
+    // Since the hugepages directories are of the form hugepages-${size}kB, we're guaranteed that,
+    // barring a huge change, Linux will never support hugepages smaller than 1kB. Since this
+    // interface replaces the /proc/meminfo interface, and thus must support expressing anything
+    // that that interface can express, we also know that /proc/meminfo cannot support hugepages
+    // smaller than 1kB. Thus, this 'size < 1024' check can never produce a false positive.
+    if size < 1024 || !size.is_power_of_two() {
+        return false;
+    }
+
+    match size.trailing_zeros() {
+        10 => *lazy::HUGEPAGE_SUPPORTED_10,
+        11 => *lazy::HUGEPAGE_SUPPORTED_11,
+        12 => *lazy::HUGEPAGE_SUPPORTED_12,
+        13 => *lazy::HUGEPAGE_SUPPORTED_13,
+        14 => *lazy::HUGEPAGE_SUPPORTED_14,
+        15 => *lazy::HUGEPAGE_SUPPORTED_15,
+        16 => *lazy::HUGEPAGE_SUPPORTED_16,
+        17 => *lazy::HUGEPAGE_SUPPORTED_17,
+        18 => *lazy::HUGEPAGE_SUPPORTED_18,
+        19 => *lazy::HUGEPAGE_SUPPORTED_19,
+        20 => *lazy::HUGEPAGE_SUPPORTED_20,
+        21 => *lazy::HUGEPAGE_SUPPORTED_21,
+        22 => *lazy::HUGEPAGE_SUPPORTED_22,
+        23 => *lazy::HUGEPAGE_SUPPORTED_23,
+        24 => *lazy::HUGEPAGE_SUPPORTED_24,
+        25 => *lazy::HUGEPAGE_SUPPORTED_25,
+        26 => *lazy::HUGEPAGE_SUPPORTED_26,
+        27 => *lazy::HUGEPAGE_SUPPORTED_27,
+        28 => *lazy::HUGEPAGE_SUPPORTED_28,
+        29 => *lazy::HUGEPAGE_SUPPORTED_29,
+        30 => *lazy::HUGEPAGE_SUPPORTED_30,
+        31 => *lazy::HUGEPAGE_SUPPORTED_31,
+        _ => unreachable!(),
+    }
+}
+
+/// Determine whether huge pages of a particular size are supported.
+#[cfg(target_os = "linux")]
+#[cfg_attr(feature = "cargo-clippy", allow(inline_always))]
+#[inline(always)]
+#[cfg(all(feature = "nightly", target_pointer_width = "64"))]
+pub fn hugepage_supported(size: usize) -> bool {
+    // Since the hugepages directories are of the form hugepages-${size}kB, we're guaranteed that,
+    // barring a huge change, Linux will never support hugepages smaller than 1kB. Since this
+    // interface replaces the /proc/meminfo interface, and thus must support expressing anything
+    // that that interface can express, we also know that /proc/meminfo cannot support hugepages
+    // smaller than 1kB. Thus, this 'size < 1024' check can never produce a false positive.
+    if size < 1024 || !size.is_power_of_two() {
+        return false;
+    }
+
+    match size.trailing_zeros() {
+        10 => *lazy::HUGEPAGE_SUPPORTED_10,
+        11 => *lazy::HUGEPAGE_SUPPORTED_11,
+        12 => *lazy::HUGEPAGE_SUPPORTED_12,
+        13 => *lazy::HUGEPAGE_SUPPORTED_13,
+        14 => *lazy::HUGEPAGE_SUPPORTED_14,
+        15 => *lazy::HUGEPAGE_SUPPORTED_15,
+        16 => *lazy::HUGEPAGE_SUPPORTED_16,
+        17 => *lazy::HUGEPAGE_SUPPORTED_17,
+        18 => *lazy::HUGEPAGE_SUPPORTED_18,
+        19 => *lazy::HUGEPAGE_SUPPORTED_19,
+        20 => *lazy::HUGEPAGE_SUPPORTED_20,
+        21 => *lazy::HUGEPAGE_SUPPORTED_21,
+        22 => *lazy::HUGEPAGE_SUPPORTED_22,
+        23 => *lazy::HUGEPAGE_SUPPORTED_23,
+        24 => *lazy::HUGEPAGE_SUPPORTED_24,
+        25 => *lazy::HUGEPAGE_SUPPORTED_25,
+        26 => *lazy::HUGEPAGE_SUPPORTED_26,
+        27 => *lazy::HUGEPAGE_SUPPORTED_27,
+        28 => *lazy::HUGEPAGE_SUPPORTED_28,
+        29 => *lazy::HUGEPAGE_SUPPORTED_29,
+        30 => *lazy::HUGEPAGE_SUPPORTED_30,
+        31 => *lazy::HUGEPAGE_SUPPORTED_31,
+        32 => *lazy::HUGEPAGE_SUPPORTED_32,
+        33 => *lazy::HUGEPAGE_SUPPORTED_33,
+        34 => *lazy::HUGEPAGE_SUPPORTED_34,
+        35 => *lazy::HUGEPAGE_SUPPORTED_35,
+        36 => *lazy::HUGEPAGE_SUPPORTED_36,
+        37 => *lazy::HUGEPAGE_SUPPORTED_37,
+        38 => *lazy::HUGEPAGE_SUPPORTED_38,
+        39 => *lazy::HUGEPAGE_SUPPORTED_39,
+        40 => *lazy::HUGEPAGE_SUPPORTED_40,
+        41 => *lazy::HUGEPAGE_SUPPORTED_41,
+        42 => *lazy::HUGEPAGE_SUPPORTED_42,
+        43 => *lazy::HUGEPAGE_SUPPORTED_43,
+        44 => *lazy::HUGEPAGE_SUPPORTED_44,
+        45 => *lazy::HUGEPAGE_SUPPORTED_45,
+        46 => *lazy::HUGEPAGE_SUPPORTED_46,
+        47 => *lazy::HUGEPAGE_SUPPORTED_47,
+        48 => *lazy::HUGEPAGE_SUPPORTED_48,
+        49 => *lazy::HUGEPAGE_SUPPORTED_49,
+        50 => *lazy::HUGEPAGE_SUPPORTED_50,
+        51 => *lazy::HUGEPAGE_SUPPORTED_51,
+        52 => *lazy::HUGEPAGE_SUPPORTED_52,
+        53 => *lazy::HUGEPAGE_SUPPORTED_53,
+        54 => *lazy::HUGEPAGE_SUPPORTED_54,
+        55 => *lazy::HUGEPAGE_SUPPORTED_55,
+        56 => *lazy::HUGEPAGE_SUPPORTED_56,
+        57 => *lazy::HUGEPAGE_SUPPORTED_57,
+        58 => *lazy::HUGEPAGE_SUPPORTED_58,
+        59 => *lazy::HUGEPAGE_SUPPORTED_59,
+        60 => *lazy::HUGEPAGE_SUPPORTED_60,
+        61 => *lazy::HUGEPAGE_SUPPORTED_61,
+        62 => *lazy::HUGEPAGE_SUPPORTED_62,
+        63 => *lazy::HUGEPAGE_SUPPORTED_63,
+        _ => unreachable!(),
+    }
+}
+
+/// Determine whether huge pages of a particular size are supported.
+#[cfg(target_os = "linux")]
+#[cfg_attr(feature = "cargo-clippy", allow(inline_always))]
+#[inline(always)]
+#[cfg(not(feature = "nightly"))]
+pub fn hugepage_supported(size: usize) -> bool {
+    // Since the hugepages directories are of the form hugepages-${size}kB, we're guaranteed that,
+    // barring a huge change, Linux will never support hugepages smaller than 1kB. Since this
+    // interface replaces the /proc/meminfo interface, and thus must support expressing anything
+    // that that interface can express, we also know that /proc/meminfo cannot support hugepages
+    // smaller than 1kB. Thus, this 'size < 1024' check can never produce a false positive.
+    if size < 1024 || !size.is_power_of_two() {
+        return false;
+    }
+
+    priv_hugepage_supported(size.trailing_zeros() as usize)
+}
+
+#[cfg(feature = "nightly")]
+#[cfg(all(target_os = "linux", target_pointer_width = "31"))]
+mod lazy {
+    use super::priv_hugepage_supported;
+    // Doing this all in a single lazy_static block causes the macro expansion pass to exceed its
+    // recursion limit. This is ugly, but it works. It's also the reason that this is in its own
+    // module - so that the single #[cfg] directive can apply to the whole module rather than
+    // having to repeat it for each lazy_static block.
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_10: bool = priv_hugepage_supported(10); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_11: bool = priv_hugepage_supported(11); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_12: bool = priv_hugepage_supported(12); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_13: bool = priv_hugepage_supported(13); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_14: bool = priv_hugepage_supported(14); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_15: bool = priv_hugepage_supported(15); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_16: bool = priv_hugepage_supported(16); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_17: bool = priv_hugepage_supported(17); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_18: bool = priv_hugepage_supported(18); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_19: bool = priv_hugepage_supported(19); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_20: bool = priv_hugepage_supported(20); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_21: bool = priv_hugepage_supported(21); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_22: bool = priv_hugepage_supported(22); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_23: bool = priv_hugepage_supported(23); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_24: bool = priv_hugepage_supported(24); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_25: bool = priv_hugepage_supported(25); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_26: bool = priv_hugepage_supported(26); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_27: bool = priv_hugepage_supported(27); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_28: bool = priv_hugepage_supported(28); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_29: bool = priv_hugepage_supported(29); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_30: bool = priv_hugepage_supported(30); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_31: bool = priv_hugepage_supported(31); }
+}
+
+#[cfg(feature = "nightly")]
+#[cfg(all(target_os = "linux", target_pointer_width = "64"))]
+mod lazy {
+    use super::priv_hugepage_supported;
+    // Doing this all in a single lazy_static block causes the macro expansion pass to exceed its
+    // recursion limit. This is ugly, but it works. It's also the reason that this is in its own
+    // module - so that the single #[cfg] directive can apply to the whole module rather than
+    // having to repeat it for each lazy_static block.
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_10: bool = priv_hugepage_supported(10); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_11: bool = priv_hugepage_supported(11); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_12: bool = priv_hugepage_supported(12); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_13: bool = priv_hugepage_supported(13); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_14: bool = priv_hugepage_supported(14); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_15: bool = priv_hugepage_supported(15); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_16: bool = priv_hugepage_supported(16); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_17: bool = priv_hugepage_supported(17); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_18: bool = priv_hugepage_supported(18); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_19: bool = priv_hugepage_supported(19); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_20: bool = priv_hugepage_supported(20); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_21: bool = priv_hugepage_supported(21); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_22: bool = priv_hugepage_supported(22); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_23: bool = priv_hugepage_supported(23); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_24: bool = priv_hugepage_supported(24); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_25: bool = priv_hugepage_supported(25); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_26: bool = priv_hugepage_supported(26); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_27: bool = priv_hugepage_supported(27); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_28: bool = priv_hugepage_supported(28); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_29: bool = priv_hugepage_supported(29); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_30: bool = priv_hugepage_supported(30); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_31: bool = priv_hugepage_supported(31); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_32: bool = priv_hugepage_supported(32); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_33: bool = priv_hugepage_supported(33); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_34: bool = priv_hugepage_supported(34); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_35: bool = priv_hugepage_supported(35); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_36: bool = priv_hugepage_supported(36); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_37: bool = priv_hugepage_supported(37); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_38: bool = priv_hugepage_supported(38); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_39: bool = priv_hugepage_supported(39); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_40: bool = priv_hugepage_supported(40); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_41: bool = priv_hugepage_supported(41); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_42: bool = priv_hugepage_supported(42); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_43: bool = priv_hugepage_supported(43); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_44: bool = priv_hugepage_supported(44); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_45: bool = priv_hugepage_supported(45); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_46: bool = priv_hugepage_supported(46); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_47: bool = priv_hugepage_supported(47); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_48: bool = priv_hugepage_supported(48); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_49: bool = priv_hugepage_supported(49); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_50: bool = priv_hugepage_supported(50); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_51: bool = priv_hugepage_supported(51); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_52: bool = priv_hugepage_supported(52); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_53: bool = priv_hugepage_supported(53); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_54: bool = priv_hugepage_supported(54); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_55: bool = priv_hugepage_supported(55); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_56: bool = priv_hugepage_supported(56); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_57: bool = priv_hugepage_supported(57); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_58: bool = priv_hugepage_supported(58); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_59: bool = priv_hugepage_supported(59); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_60: bool = priv_hugepage_supported(60); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_61: bool = priv_hugepage_supported(61); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_62: bool = priv_hugepage_supported(62); }
+    lazy_static!{ pub static ref HUGEPAGE_SUPPORTED_63: bool = priv_hugepage_supported(63); }
+}
+
+#[cfg(all(target_os = "linux", target_pointer_width = "32"))]
+macro_rules! get_linux_hugepage_directory {
+    ($size:expr) => (
+        match $size {
+            10 => "/sys/kernel/mm/hugepages/hugepages-1kB",
+            11 => "/sys/kernel/mm/hugepages/hugepages-2kB",
+            12 => "/sys/kernel/mm/hugepages/hugepages-4kB",
+            13 => "/sys/kernel/mm/hugepages/hugepages-8kB",
+            14 => "/sys/kernel/mm/hugepages/hugepages-16kB",
+            15 => "/sys/kernel/mm/hugepages/hugepages-32kB",
+            16 => "/sys/kernel/mm/hugepages/hugepages-64kB",
+            17 => "/sys/kernel/mm/hugepages/hugepages-128kB",
+            18 => "/sys/kernel/mm/hugepages/hugepages-256kB",
+            19 => "/sys/kernel/mm/hugepages/hugepages-512kB",
+            20 => "/sys/kernel/mm/hugepages/hugepages-1024kB",
+            21 => "/sys/kernel/mm/hugepages/hugepages-2048kB",
+            22 => "/sys/kernel/mm/hugepages/hugepages-4096kB",
+            23 => "/sys/kernel/mm/hugepages/hugepages-8192kB",
+            24 => "/sys/kernel/mm/hugepages/hugepages-16384kB",
+            25 => "/sys/kernel/mm/hugepages/hugepages-32768kB",
+            26 => "/sys/kernel/mm/hugepages/hugepages-65536kB",
+            27 => "/sys/kernel/mm/hugepages/hugepages-131072kB",
+            28 => "/sys/kernel/mm/hugepages/hugepages-262144kB",
+            29 => "/sys/kernel/mm/hugepages/hugepages-524288kB",
+            30 => "/sys/kernel/mm/hugepages/hugepages-1048576kB",
+            31 => "/sys/kernel/mm/hugepages/hugepages-2097152kB",
+            _ => unreachable!(),
+        }
+    );
+}
+
+#[cfg(all(target_os = "linux", target_pointer_width = "64"))]
+macro_rules! get_linux_hugepage_directory {
+    ($size:expr) => (
+        match $size {
+            10 => "/sys/kernel/mm/hugepages/hugepages-1kB",
+            11 => "/sys/kernel/mm/hugepages/hugepages-2kB",
+            12 => "/sys/kernel/mm/hugepages/hugepages-4kB",
+            13 => "/sys/kernel/mm/hugepages/hugepages-8kB",
+            14 => "/sys/kernel/mm/hugepages/hugepages-16kB",
+            15 => "/sys/kernel/mm/hugepages/hugepages-32kB",
+            16 => "/sys/kernel/mm/hugepages/hugepages-64kB",
+            17 => "/sys/kernel/mm/hugepages/hugepages-128kB",
+            18 => "/sys/kernel/mm/hugepages/hugepages-256kB",
+            19 => "/sys/kernel/mm/hugepages/hugepages-512kB",
+            20 => "/sys/kernel/mm/hugepages/hugepages-1024kB",
+            21 => "/sys/kernel/mm/hugepages/hugepages-2048kB",
+            22 => "/sys/kernel/mm/hugepages/hugepages-4096kB",
+            23 => "/sys/kernel/mm/hugepages/hugepages-8192kB",
+            24 => "/sys/kernel/mm/hugepages/hugepages-16384kB",
+            25 => "/sys/kernel/mm/hugepages/hugepages-32768kB",
+            26 => "/sys/kernel/mm/hugepages/hugepages-65536kB",
+            27 => "/sys/kernel/mm/hugepages/hugepages-131072kB",
+            28 => "/sys/kernel/mm/hugepages/hugepages-262144kB",
+            29 => "/sys/kernel/mm/hugepages/hugepages-524288kB",
+            30 => "/sys/kernel/mm/hugepages/hugepages-1048576kB",
+            31 => "/sys/kernel/mm/hugepages/hugepages-2097152kB",
+            32 => "/sys/kernel/mm/hugepages/hugepages-4194304kB",
+            33 => "/sys/kernel/mm/hugepages/hugepages-8388608kB",
+            34 => "/sys/kernel/mm/hugepages/hugepages-16777216kB",
+            35 => "/sys/kernel/mm/hugepages/hugepages-33554432kB",
+            36 => "/sys/kernel/mm/hugepages/hugepages-67108864kB",
+            37 => "/sys/kernel/mm/hugepages/hugepages-134217728kB",
+            38 => "/sys/kernel/mm/hugepages/hugepages-268435456kB",
+            39 => "/sys/kernel/mm/hugepages/hugepages-536870912kB",
+            40 => "/sys/kernel/mm/hugepages/hugepages-1073741824kB",
+            41 => "/sys/kernel/mm/hugepages/hugepages-2147483648kB",
+            42 => "/sys/kernel/mm/hugepages/hugepages-4294967296kB",
+            43 => "/sys/kernel/mm/hugepages/hugepages-8589934592kB",
+            44 => "/sys/kernel/mm/hugepages/hugepages-17179869184kB",
+            45 => "/sys/kernel/mm/hugepages/hugepages-34359738368kB",
+            46 => "/sys/kernel/mm/hugepages/hugepages-68719476736kB",
+            47 => "/sys/kernel/mm/hugepages/hugepages-137438953472kB",
+            48 => "/sys/kernel/mm/hugepages/hugepages-274877906944kB",
+            49 => "/sys/kernel/mm/hugepages/hugepages-549755813888kB",
+            50 => "/sys/kernel/mm/hugepages/hugepages-1099511627776kB",
+            51 => "/sys/kernel/mm/hugepages/hugepages-2199023255552kB",
+            52 => "/sys/kernel/mm/hugepages/hugepages-4398046511104kB",
+            53 => "/sys/kernel/mm/hugepages/hugepages-8796093022208kB",
+            54 => "/sys/kernel/mm/hugepages/hugepages-17592186044416kB",
+            55 => "/sys/kernel/mm/hugepages/hugepages-35184372088832kB",
+            56 => "/sys/kernel/mm/hugepages/hugepages-70368744177664kB",
+            57 => "/sys/kernel/mm/hugepages/hugepages-140737488355328kB",
+            58 => "/sys/kernel/mm/hugepages/hugepages-281474976710656kB",
+            59 => "/sys/kernel/mm/hugepages/hugepages-562949953421312kB",
+            60 => "/sys/kernel/mm/hugepages/hugepages-1125899906842624kB",
+            61 => "/sys/kernel/mm/hugepages/hugepages-2251799813685248kB",
+            62 => "/sys/kernel/mm/hugepages/hugepages-4503599627370496kB",
+            63 => "/sys/kernel/mm/hugepages/hugepages-9007199254740992kB",
+            _ => unreachable!(),
+        }
+    );
+}
+
+#[cfg(target_os = "linux")]
+fn priv_hugepage_supported(exp: usize) -> bool {
+    // See for details: https://www.kernel.org/doc/Documentation/vm/hugetlbpage.txt
+    // First, use the more modern method of checking /sys/kernel/mm/hugepages/hugepages-${size}kB.
+    // If that fails (possibly because we're on an old kernel version), try the legacy method of
+    // parsing /proc/meminfo (described in more detail in legacy_hugepage_supported below).
+
+    use self::libc::{stat, lstat, ENOENT, ENOMEM};
+    use self::errno::errno;
+    use core::mem::uninitialized;
+
+    let path = get_linux_hugepage_directory!(exp);
+
+    let mut s = unsafe { uninitialized::<stat>() };
+    if unsafe { lstat(path.as_ptr() as *const i8, &mut s) } < 0 {
+        // No other error should be possible here (see man 2 lstat)
+        let e = errno().0;
+        assert!(e == ENOENT || e == ENOMEM);
+        if e == ENOENT {
+            // Maybe we're on an older kernel that doesn't support /sys/kernel/mm/hugepages;
+            // it will still support /proc/meminfo, which is what default_hugepage uses.
+            default_hugepage() == Some(1 << exp)
+        } else {
+            false
+        }
+    } else {
+        true
+    }
+}
+
+/// Get the system's default huge page size.
+///
+/// If no huge pages are supported, `default_hugepage` will return `None`.
+#[cfg(any(target_os = "linux", windows))]
+#[cfg_attr(feature = "cargo-clippy", allow(inline_always))]
+#[inline(always)]
+#[cfg(feature = "nightly")]
+pub fn default_hugepage() -> Option<usize> {
+    *DEFAULT_HUGEPAGE
+}
+
+/// Get the system's default huge page size.
+///
+/// If no huge pages are supported, `default_hugepage` will return `None`.
+#[cfg(any(target_os = "linux", windows))]
+#[cfg_attr(feature = "cargo-clippy", allow(inline_always))]
+#[inline(always)]
+#[cfg(not(feature = "nightly"))]
+pub fn default_hugepage() -> Option<usize> {
+    priv_default_hugepage()
+}
+
+#[cfg(feature = "nightly")]
+#[cfg(any(target_os = "linux", windows))]
+lazy_static!{ static ref DEFAULT_HUGEPAGE: Option<usize> = priv_default_hugepage(); }
+
+#[cfg(target_os = "linux")]
+fn priv_default_hugepage() -> Option<usize> {
+    // Parse /proc/meminfo looking for the line 'Hugepagesize: xxx kB'.
+    // TODO(joshlf): Implement
+    None
+}
+
+#[cfg(windows)]
+fn priv_default_hugepage() -> Option<usize> {
+    use kernel32::GetLargePageMinimum;
+    unsafe {
+        let size = GetLargePageMinimum();
+        // While u64 (GetLargePageMinimum's return type) might be larger than usize (on 32-bit
+        // systems), if 'size' were to overflow usize (and thus be larger than 2^32), that would
+        // imply that the huge page size was too large for the address of the second huge page on
+        // the system to be representable with a pointer. Obviously that wouldn't happen, so we
+        // don't bother to check for overflow.
+        if size == 0 { None } else { Some(size as usize) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_hugepage_supported() {
+        use core::usize::MAX;
+        use std::fs::metadata;
+        use super::hugepage_supported;
+
+        let max = MAX - (MAX >> 1); // largest power of two representable by usize
+        let mut size = 512; // start off at 512 so it will be 1024 in the first loop iteration
+        // this has the effect of letting size <= max after the 'size *= 2' line
+        while size < max {
+            size *= 2;
+            let path = get_linux_hugepage_directory!(size.trailing_zeros());
+
+            let supported = match metadata(path) {
+                Ok(_) => true,
+                Err(_) => false,
+            };
+
+            assert_eq!(supported, hugepage_supported(size));
+        }
+    }
+}

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -1,0 +1,54 @@
+//! Query for configuration related to memory pages.
+//!
+//! # Huge Pages
+//! Some systems support "huge pages" that are larger than the system's default page size. In the
+//! documentation for this module, we use the Linux name of "huge pages," although they go by
+//! different names on different platforms - superpages on Mac, and large pages on Windows.
+
+#[cfg(windows)]
+extern crate kernel32;
+#[cfg(windows)]
+extern crate winapi;
+
+mod hugepage;
+pub use self::hugepage::*;
+
+/// Get the system's page size.
+#[cfg(any(unix, windows))]
+#[cfg_attr(feature = "cargo-clippy", allow(inline_always))]
+#[inline(always)]
+#[cfg(feature = "nightly")]
+pub fn pagesize() -> usize {
+    *PAGESIZE
+}
+
+/// Get the system's page size.
+#[cfg(any(unix, windows))]
+#[cfg_attr(feature = "cargo-clippy", allow(inline_always))]
+#[inline(always)]
+#[cfg(not(feature = "nightly"))]
+pub fn pagesize() -> usize {
+    priv_pagesize()
+}
+
+#[cfg(feature = "nightly")]
+#[cfg(any(unix, windows))]
+lazy_static!{ static ref PAGESIZE: usize = priv_pagesize(); }
+
+#[cfg(unix)]
+fn priv_pagesize() -> usize {
+    // sysconf(_SC_PAGESIZE) is required by POSIX 1003.1: http://www.unix.com/man-page/posix/3p/sysconf/
+    ::raw::sysconf(::raw::SysconfVariable::ScPagesize).expect("sysconf(_SC_PAGESIZE) failed, but _SC_PAGESIZE is required by POSIX 1003.1") as usize
+}
+
+#[cfg(windows)]
+fn priv_pagesize() -> usize {
+    use self::kernel32::GetSystemInfo;
+    use self::winapi::SYSTEM_INFO;
+    use core::mem::uninitialized;
+    unsafe {
+        let mut info = uninitialized::<SYSTEM_INFO>();
+        GetSystemInfo(&mut info);
+        info.dwPageSize as usize
+    }
+}

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,0 +1,116 @@
+//! Directly the `sysconf` function.
+//!
+//! Unlike the other modules in this crate, which provide convenience wrappers to query various
+//! configuration information, the `raw` module provides the ability to call the `sysconf` function
+//! directly.
+
+extern crate libc;
+use self::libc::c_int;
+use core::result;
+
+pub type Result<T> = result::Result<T, SysconfError>;
+
+/// The error returned by `sysconf`.
+#[derive(Debug)]
+pub enum SysconfError {
+    /// The queried variable is unsupported on the current system.
+    Unsupported,
+}
+
+macro_rules! sc { ($var:ident) => (libc::$var as isize) }
+
+/// The variables that can be queried using `sysconf`.
+///
+/// Each variable corresponds to a sysconf variable defined by POSIX. For example, `ScArgMax`
+/// corresponds to the `_SC_ARG_MAX` variable, and so on.
+///
+/// Different variables may have been added at different times, and as a result, some variables
+/// may not be supported on older systems. In these cases, `sysconf` will return an error.
+pub enum SysconfVariable {
+    ScArgMax = sc!(_SC_ARG_MAX),
+    ScChildMax = sc!(_SC_CHILD_MAX),
+    ScClkTck = sc!(_SC_CLK_TCK),
+    ScNgroupsMax = sc!(_SC_NGROUPS_MAX),
+    ScOpenMax = sc!(_SC_OPEN_MAX),
+    ScStreamMax = sc!(_SC_STREAM_MAX),
+    ScTznameMax = sc!(_SC_TZNAME_MAX),
+    ScJobControl = sc!(_SC_JOB_CONTROL),
+    ScSavedIds = sc!(_SC_SAVED_IDS),
+    ScRealtimeSignals = sc!(_SC_REALTIME_SIGNALS),
+    ScPriorityScheduling = sc!(_SC_PRIORITY_SCHEDULING),
+    ScTimers = sc!(_SC_TIMERS),
+    ScAsynchronousIo = sc!(_SC_ASYNCHRONOUS_IO),
+    ScPrioritizedIo = sc!(_SC_PRIORITIZED_IO),
+    ScSynchronizedIo = sc!(_SC_SYNCHRONIZED_IO),
+    ScFsync = sc!(_SC_FSYNC),
+    ScMappedFiles = sc!(_SC_MAPPED_FILES),
+    ScMemlock = sc!(_SC_MEMLOCK),
+    ScMemlockRange = sc!(_SC_MEMLOCK_RANGE),
+    ScMemoryProtection = sc!(_SC_MEMORY_PROTECTION),
+    ScMessagePassing = sc!(_SC_MESSAGE_PASSING),
+    ScSemaphores = sc!(_SC_SEMAPHORES),
+    ScSharedMemoryObjects = sc!(_SC_SHARED_MEMORY_OBJECTS),
+    ScAioListioMax = sc!(_SC_AIO_LISTIO_MAX),
+    ScAioMax = sc!(_SC_AIO_MAX),
+    ScAioPrioDeltaMax = sc!(_SC_AIO_PRIO_DELTA_MAX),
+    ScDelaytimerMax = sc!(_SC_DELAYTIMER_MAX),
+    ScMqOpenMax = sc!(_SC_MQ_OPEN_MAX),
+    ScVersion = sc!(_SC_VERSION),
+    ScPagesize = sc!(_SC_PAGESIZE),
+    ScRtsigMax = sc!(_SC_RTSIG_MAX),
+    ScSemNsemsMax = sc!(_SC_SEM_NSEMS_MAX),
+    ScSemValueMax = sc!(_SC_SEM_VALUE_MAX),
+    ScSigqueueMax = sc!(_SC_SIGQUEUE_MAX),
+    ScTimerMax = sc!(_SC_TIMER_MAX),
+    ScBcBaseMax = sc!(_SC_BC_BASE_MAX),
+    ScBcDimMax = sc!(_SC_BC_DIM_MAX),
+    ScBcScaleMax = sc!(_SC_BC_SCALE_MAX),
+    ScBcStringMax = sc!(_SC_BC_STRING_MAX),
+    ScCollWeightsMax = sc!(_SC_COLL_WEIGHTS_MAX),
+    ScExprNestMax = sc!(_SC_EXPR_NEST_MAX),
+    ScLineMax = sc!(_SC_LINE_MAX),
+    ScReDupMax = sc!(_SC_RE_DUP_MAX),
+    Sc2Version = sc!(_SC_2_VERSION),
+    Sc2CBind = sc!(_SC_2_C_BIND),
+    Sc2CDev = sc!(_SC_2_C_DEV),
+    Sc2FortDev = sc!(_SC_2_FORT_DEV),
+    Sc2FortRun = sc!(_SC_2_FORT_RUN),
+    Sc2SwDev = sc!(_SC_2_SW_DEV),
+    Sc2Localedef = sc!(_SC_2_LOCALEDEF),
+    ScNprocessorsOnln = sc!(_SC_NPROCESSORS_ONLN),
+    Sc2CharTerm = sc!(_SC_2_CHAR_TERM),
+    Sc2CVersion = 96, // TODO(joshlf): Switch to a libc constant once it's added
+    Sc2Upe = sc!(_SC_2_UPE),
+    ScXbs5Ilp32Off32 = sc!(_SC_XBS5_ILP32_OFF32),
+    ScXbs5Ilp32Offbig = sc!(_SC_XBS5_ILP32_OFFBIG),
+    ScXbs5LpbigOffbig = sc!(_SC_XBS5_LPBIG_OFFBIG),
+}
+
+/// Query the system's configuration.
+///
+/// `sysconf` calls the POSIX `sysconf` function from the system's `libc`. The result is either an
+/// `isize` representing the queried variable's value, or an error indicating that the queried
+/// variable is not supported on the current system.
+pub fn sysconf(name: SysconfVariable) -> Result<isize> {
+    // TODO(joshlf): What error conditions are possible?
+    // - On Linux, EINVAL implies that an unknown variable was requested, and no other errors are
+    //   possible.
+    // - On Mac, -1 with errno changed means that there was a failure to query the configuration,
+    //   while -1 with errno unchanged means that an unknown variable was requested. It's not clear
+    //   to me (joshlf) that it's always possible to distinguish between these two scenarios.
+    match unsafe { libc::sysconf(name as c_int) } {
+        -1 => Err(SysconfError::Unsupported),
+        ret => Ok(ret as isize),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_sysconf() {
+        let result = sysconf(SysconfVariable::ScPagesize);
+        assert!(result.is_ok())
+    }
+}


### PR DESCRIPTION
This PR makes the following changes:
- Adds a `page` module that provides functions which can query various information related to memory pages
- Moves `sysconf` and related types to a `raw` module to distinguish it from modules that provide higher-level wrappers
- Changes the return type of `sysconf` from `Result<c_long>` to `Result<isize>` (see CHANGELOG for details)
- Adds documentation in a number of places
- Bumps the version to 0.3.0

If you want to take the PR as is, then it's ready for that, but I'm also happy to discuss changes/further improvements/etc.